### PR TITLE
Correção de erros gramaticais na documentação do MUD

### DIFF
--- a/mud/doc/01-ativar-o-mud.txt
+++ b/mud/doc/01-ativar-o-mud.txt
@@ -25,19 +25,19 @@ Há pelo menos três formas de baixar e compilar o IntMUD:
 
 2.1. Baixar a última revisão pelo servidor, com o programa wget
 
-São os seguinte comandos, nessa ordem:
+São os seguintes comandos, nessa ordem:
 wget https://github.com/ed2martin/intmud/archive/master.zip
 unzip master.zip
 cd intmud-master
 ./configure && make
 
 Pode acontecer do wget salvar o arquivo como master ao invés de master.zip.
-Nesse caso, o comando para descompacter muda de unzip master.zip para
+Nesse caso, o comando para descompactar muda de unzip master.zip para
 unzip master
 
 2.2. Baixar a última revisão pelo servidor, com o programa git
 
-São os seguinte comandos, nessa ordem:
+São os seguintes comandos, nessa ordem:
 git clone git://github.com/ed2martin/intmud
 unzip master.zip
 cd intmud


### PR DESCRIPTION
Substituir, onde se encontrava seguinte comandos para seguintes comandos no arquivo mud/doc/01 - Ativar o Mud.txt, além da palavra descompactar, que estava escrita como descompacter em certo momento.'