### PR TITLE
Correção de Bug

### DIFF
--- a/mud/cmd/canais.int
+++ b/mud/cmd/canais.int
@@ -18,10 +18,10 @@ const m_nivel = "Para usar o comando CHAT você precisa chegar no nível $m."
 const v_nivel = 0
 const m_desab = "Canal CHAT está desabilitado; para habilitar tecle CONFIG +CHAT"
 const m_sem_args = "Tecle a mensagem após CHAT."
-const m_msg1 = "(chat) $R '$m'"
-const m_msg2 = "(chat) $R '$m'"
+const m_msg1 = "(chat) $R disse '$m'"
+const m_msg2 = "(chat) $R disse '$m'"
 const v_tipo = 2
-const admordem = "m_ajuda1 m_ajuda2 m_nivel v_nivel m_desab m_sem_args m_msg v_tipo"
+const admordem = "m_ajuda1 m_ajuda2 m_nivel v_nivel m_desab m_sem_args m_msg1 m_msg2 v_tipo"
 
 func escr
   $mens.p(arg0)


### PR DESCRIPTION
No MUD, arquivo mud/cmd/canais.int:
Corrigido bug na classe h_cmd_chat: na const cujo nome é admordem, foi retirada referência à constante m_msg (inexistente). Por sua vez, foram adicionadas outras duas: m_msg1 e m_msg2. Tal erro fazia com que os itens m_msg1 e m_msg2 ficassem sempre ao final da classe cmd_chat, isso se a mesma fosse alterada pelo menu de edição correspondente.