### PR TITLE
Correção de Erros de Ortografia

### DIFF
--- a/mud/adm/area-sala.int
+++ b/mud/adm/area-sala.int
@@ -725,7 +725,7 @@ const tipo2 = "opc_texto"
 const vari2 = "s_desc"
 #
 const nome3 = "Desc de noite"
-const info3 = "Se quiser uma descrição diferente quando etiver de noite"
+const info3 = "Se quiser uma descrição diferente quando estiver de noite"
 const tipo3 = "opc_texto"
 const vari3 = "s_noite"
 #

--- a/mud/adm/econfig.int
+++ b/mud/adm/econfig.int
@@ -1229,7 +1229,7 @@ const tipo2 = "opc_numero--"
 const vari2 = "s_objmax"
 #
 const nome3 = "Movimentos ataque"
-const info3 = "Quantidade de movimentos que um ataque de outra sala usa para checar nessa"
+const info3 = "Quantidade de movimentos que um ataque de outra sala usa para chegar nessa"
 const tipo3 = "opc_numero--"
 const vari3 = "s_atk_move"
 #

--- a/mud/adm/econfig.int
+++ b/mud/adm/econfig.int
@@ -606,7 +606,7 @@ const tipo5 = "opc_linha--"
 const vari5 = "criar_msgadm"
 #
 const nome6 = "Desistiu de criar"
-const info6 = "Mensagem quando desistiu de criando personagem, para administradores\n\
+const info6 = "Mensagem quando desistiu de criar personagem, para administradores\n\
 $P Personagem, $C Conexão, $$ símbolo $"
 const tipo6 = "opc_linha--"
 const vari6 = "naocriar_msgadm"

--- a/mud/adm/econfig.int
+++ b/mud/adm/econfig.int
@@ -631,11 +631,11 @@ const menufim = "menu_econfig_msg"
 const colunas = 35
 const classe = "config"
 #
-const nome1 = "1 horas"
+const nome1 = "1 hora"
 const tipo1 = "opc_linha"
 const vari1 = "horamsg1"
 #
-const nome2 = "2 hora"
+const nome2 = "2 horas"
 const tipo2 = "opc_linha"
 const vari2 = "horamsg2"
 #


### PR DESCRIPTION
No MUD:
Arquivo mud/adm/area-sala.int, classe menu_sala: substituído verbo etiver por estiver na opção 3 do menu (Desc de noite).
Arquivo mud/adm/econfig.int, classe menu_econfig_entrasai: na opção 6 do menu (Desistiu de criar), mais especificamente na constante de informações, foi substituído o termo "desistiu de criando" por "desistiu de criar".
Classe menu_econfig_hora: o título da opção 1 foi substituído de "1 horas" para "1 hora", enquanto que o da opção 2 foi corrigido de "2 hora" para "2 horas".
Classe menu_econfig_herda1: na opção 3 do menu (Movimentos ataque), mais especificamente em se tratando da constante de informações, foi substituída a palavra "checar" por "chegar".