### PR TITLE
Correção de Erros Gramaticais

### DIFF
--- a/mud/adm/menus.int
+++ b/mud/adm/menus.int
@@ -4,7 +4,7 @@ const txt_legenda = "Legenda:\n\
 <nulo> Significa que a opção não foi definida.\n\
 <herda> É herdado de outra classe.\n\
 Exemplo, as salas herdam as propriedades das áreas.\n\
-Outro texto entre os sinais de menor e maior indicam o modo\n\
+Outro texto entre os sinais de menor e maior indica o modo\n\
 como a opção foi definida. Exemplo, <func> significa função."
 const menu = "<menu>"
 ref sock # Objeto jogsock do jogador

--- a/mud/adm/menus.int
+++ b/mud/adm/menus.int
@@ -3,7 +3,7 @@ herda comando_adm
 const txt_legenda = "Legenda:\n\
 <nulo> Significa que a opção não foi definida.\n\
 <herda> É herdado de outra classe.\n\
-Exemplo, as salas herdam as propriedades das nas áreas.\n\
+Exemplo, as salas herdam as propriedades das áreas.\n\
 Outro texto entre os sinais de menor e maior indicam o modo\n\
 como a opção foi definida. Exemplo, <func> significa função."
 const menu = "<menu>"


### PR DESCRIPTION
No MUD:
Arquivo mud/adm/menus.int, classe comando_menu: na constante denominada txt_legenda, em especial onde está documentado sobre <herda>, foi substituído o termo "propriedades das nas áreas" por "propriedades das áreas".
Corrigido erro de concordância, substituindo o trecho "Outro texto entre os sinais de menor e maior indicam o modo" por "Outro texto entre os sinais de menor e maior indica o modo".