### PR TITLE
Correção de Erro de Digitação em mud/doc/06-comum.txt

### DIFF
--- a/mud/doc/06-comum.txt
+++ b/mud/doc/06-comum.txt
@@ -190,7 +190,7 @@ func recalc_dono
 Ajusta variáveis do dono (principalmente batalha) se o dono for personagem.
 
 func visivel( personagem )
-Retorna verdadeiro se está visível para o persoangem.
+Retorna verdadeiro se está visível para o personagem.
 
 func mudadono( item ou personagem, quantidade )
 Item ou personagem muda de dono.


### PR DESCRIPTION
No MUD:
Onde é documentado acerca da func visivel ( personagem ), foi corrigido "persoangem" para "personagem".