### PR TITLE
Correção de Erro de Digitação em mud/obj/perso.int

### DIFF
--- a/mud/obj/perso.int
+++ b/mud/obj/perso.int
@@ -40,7 +40,7 @@ const pospadr = 8 # Posição padrão do personagem
 sav uint8 pnumero # Número do personagem ou 0 se não tem dono
 sav listaitem poslugar # Em qual móvel o personagem está sentado/deitado/montado
 sav listaobj persolugar # Quem está montado
-sav listaitem iempu # Arma que que está empunhando
+sav listaitem iempu # Arma que está empunhando
 txt12 tipoiteminv2 # Tipos de item no inventário ou "" se precisa calcular
 txt12 tipoitemvestir2 # Tipos de item vestindo ou "" se precisa calcular
 inttempo p_proc # Para processar comportamento do personagem


### PR DESCRIPTION
No MUD:
Classe comum_perso: o comentário da variável "sav listaitem iempu" foi corrigido de "Arma que que está empunhando" para "Arma que está empunhando".